### PR TITLE
Handle disabled sources in loader

### DIFF
--- a/app/loader.py
+++ b/app/loader.py
@@ -20,8 +20,8 @@ def load_sources(yaml_path: str) -> List[Source]:
         if not s.get("rss_url") and not s.get("url"):
             continue
         if not s.get("enabled", True):
-            # assume enabled by default
-            pass
+            # Skip sources explicitly marked as disabled
+            continue
         t = (s.get("type") or "rss").lower()
         name = s.get("name", "Unnamed")
         lang = s.get("language", "")


### PR DESCRIPTION
## Summary
- skip loading sources marked as disabled in YAML configuration

## Testing
- `pytest -q`
- `python -m app.main --once`


------
https://chatgpt.com/codex/tasks/task_e_68c1241379a0832b9802aaafe38d045f