### PR TITLE
Sort news by id descending

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -117,9 +117,9 @@ async def list_news(
         from sqlalchemy import and_ as _and
         stmt = stmt.where(_and(*conds))
     if order.lower() == "desc":
-        stmt = stmt.order_by(News.published_at.desc(), News.id.desc())
+        stmt = stmt.order_by(News.id.desc())
     else:
-        stmt = stmt.order_by(News.published_at.asc(), News.id.asc())
+        stmt = stmt.order_by(News.id.asc())
     stmt = stmt.limit(limit).offset(offset)
     result = await session.execute(stmt)
     rows = result.scalars().all()


### PR DESCRIPTION
## Summary
- Order news listings by `id` rather than `published_at`, defaulting to descending order

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c23beb69bc832bbcbb0352a5848e53